### PR TITLE
Fix build with bazel >= 18

### DIFF
--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -361,7 +361,7 @@ def library_closure(name, srcs, outzip = "", excludes = [], executable = False, 
         linkshared = not executable,
         linkopts = [
             "-Wl,-rpath=$$ORIGIN",
-            param_file,
+            "$(location %s)" % param_file,
             "-T$(location %s)" % dirs_file,
         ],
         srcs = [runfiles_srclibs],


### PR DESCRIPTION
Updating bazel to 18.0 broke clodl on my codebase with the error `gcc: error: my_closure-params.ld: No such file or directory`. Enforcing the full path to the `my_closure-params.ld` file in the `cc_binary` arguments fixes it