### PR TITLE
Fix the mtime of all files in the zip archive − take 2

### DIFF
--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -396,9 +396,9 @@ def library_closure(name, srcs, outzip = "", excludes = [], executable = False, 
             fi
         done
         cp $(SRCS) "$${libs[@]}" $$tmpdir
-    
+
         mkdir -p "$$outputdir"
-        zip -qjr $@ $$tmpdir
+        zip -X -qjr $@ $$tmpdir
         rm -rf $$tmpdir
 
         # Check that the excluded libraries have been really excluded.


### PR DESCRIPTION
Simplified rewrite of #28 

Needed to make it reproducible (because the mtime of the files will be included in the archive)
In particular, not doing this means that clodl won't play well with the bazel remote cache.