### PR TITLE
Simplify clodl implementation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -137,3 +137,8 @@ sh_binary(
     name = "deps",
     srcs = ["src/main/bash/deps.sh"],
 )
+
+buildifier(
+    name = "buildifier",
+    lint_mode = "warn",
+)

--- a/BUILD
+++ b/BUILD
@@ -1,31 +1,33 @@
-package(default_visibility = ["//visibility:public"])
-
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load(
     "@rules_haskell//haskell:defs.bzl",
     "haskell_binary",
-    "haskell_test",
     "haskell_toolchain_library",
 )
 load(
     "@io_tweag_clodl//clodl:clodl.bzl",
-    "library_closure",
     "binary_closure",
+    "library_closure",
 )
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "bootstrap-bz",
     srcs = ["src/main/cc/bootstrap.c"],
     copts = ["-std=c99"],
     deps = [
-        "@rules_haskell_ghc_nixpkgs//:include",
         "@openjdk//:include",
+        "@rules_haskell_ghc_nixpkgs//:include",
     ],
 )
 
 cc_binary(
     name = "libbootstrap.so",
-    deps = ["bootstrap-bz"],
     linkshared = 1,
+    deps = ["bootstrap-bz"],
 )
 
 java_library(
@@ -33,12 +35,11 @@ java_library(
     srcs = glob(["src/main/java/**/*.java"]),
 )
 
-
 haskell_toolchain_library(name = "base")
+
 haskell_binary(
     name = "hello-hs",
     testonly = True,
-    linkstatic = False,
     srcs = ["src/test/haskell/hello/Main.hs"],
     compiler_flags = [
         "-threaded",
@@ -46,21 +47,25 @@ haskell_binary(
         "-optl-Wl,--dynamic-list=main-symbol-list.ld",
     ],
     extra_srcs = ["main-symbol-list.ld"],
-    deps = [":base"],
+    linkstatic = False,
     src_strip_prefix = "src/test/haskell/hello",
+    deps = [":base"],
 )
 
 library_closure(
     name = "clotest",
     testonly = True,
-    srcs = ["hello-hs", "libbootstrap.so"],
+    srcs = [
+        "hello-hs",
+        "libbootstrap.so",
+    ],
     excludes = [
-        "ld-linux-x86-64\.so.*",
-        "libgcc_s\.so.*",
-        "libc\.so.*",
-        "libdl\.so.*",
-        "libm\.so.*",
-        "libpthread\.so.*",
+        "ld-linux-x86-64\\.so.*",
+        "libgcc_s\\.so.*",
+        "libc\\.so.*",
+        "libdl\\.so.*",
+        "libm\\.so.*",
+        "libpthread\\.so.*",
     ],
 )
 
@@ -69,12 +74,12 @@ binary_closure(
     testonly = True,
     src = "hello-hs",
     excludes = [
-        "ld-linux-x86-64\.so.*",
-        "libgcc_s\.so.*",
-        "libc\.so.*",
-        "libdl\.so.*",
-        "libm\.so.*",
-        "libpthread\.so.*",
+        "ld-linux-x86-64\\.so.*",
+        "libgcc_s\\.so.*",
+        "libc\\.so.*",
+        "libdl\\.so.*",
+        "libm\\.so.*",
+        "libpthread\\.so.*",
     ],
 )
 
@@ -88,16 +93,16 @@ java_binary(
 
 cc_library(
     name = "lib-cc",
-    srcs = ["src/test/cc/hello/lib.c"],
     testonly = True,
+    srcs = ["src/test/cc/hello/lib.c"],
 )
 
 cc_binary(
     name = "libhello-cc.so",
-    srcs = ["src/test/cc/hello/main.c"],
-    deps = ["lib-cc"],
-    linkshared = 1,
     testonly = True,
+    srcs = ["src/test/cc/hello/main.c"],
+    linkshared = 1,
+    deps = ["lib-cc"],
 )
 
 binary_closure(
@@ -108,9 +113,9 @@ binary_closure(
 
 cc_binary(
     name = "libhello-cc-norunfiles.so",
+    testonly = True,
     srcs = ["src/test/cc/hello/main.c"],
     linkshared = 1,
-    testonly = True,
 )
 
 binary_closure(
@@ -121,10 +126,13 @@ binary_closure(
 
 cc_binary(
     name = "hello-cc-pie",
-    srcs = ["src/test/cc/hello/main.c"],
-    linkopts = ["-pie", "-Wl,--dynamic-list=main-symbol-list.ld"],
-	deps = ["main-symbol-list.ld"],
     testonly = True,
+    srcs = ["src/test/cc/hello/main.c"],
+    linkopts = [
+        "-pie",
+        "-Wl,--dynamic-list=main-symbol-list.ld",
+    ],
+    deps = ["main-symbol-list.ld"],
 )
 
 binary_closure(

--- a/BUILD
+++ b/BUILD
@@ -62,7 +62,6 @@ library_closure(
         "libm\.so.*",
         "libpthread\.so.*",
     ],
-    outzip = "closure.zip",
 )
 
 binary_closure(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,7 @@ http_archive(
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "haskell_repositories")
+
 haskell_repositories()
 
 load(
@@ -41,16 +42,6 @@ filegroup(
 
 haskell_register_ghc_nixpkgs(
     attribute_path = "haskell.compiler.ghc8102",
-    locale_archive = "@glibc_locales//:locale-archive",
-    repositories = {"nixpkgs": "@nixpkgs"},
-    version = "8.10.2",
-    compiler_flags = [
-        "-Werror",
-        "-Wall",
-        "-Wcompat",
-        "-Wincomplete-record-updates",
-        "-Wredundant-constraints",
-    ],
     build_file_content = """
 package(default_visibility = [ "//visibility:public" ])
 
@@ -65,6 +56,16 @@ cc_library(
     strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
 )
 """,
+    compiler_flags = [
+        "-Werror",
+        "-Wall",
+        "-Wcompat",
+        "-Wincomplete-record-updates",
+        "-Wredundant-constraints",
+    ],
+    locale_archive = "@glibc_locales//:locale-archive",
+    repositories = {"nixpkgs": "@nixpkgs"},
+    version = "8.10.2",
 )
 
 nixpkgs_package(
@@ -81,7 +82,6 @@ cc_library(
     repository = "@nixpkgs",
 )
 
-
 http_archive(
     name = "io_bazel_stardoc",
     strip_prefix = "stardoc-0.4.0",
@@ -89,6 +89,7 @@ http_archive(
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
 stardoc_repositories()
 
 ##################################################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,3 +90,53 @@ http_archive(
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 stardoc_repositories()
+
+##################################################################
+#  buildifier setup
+##################################################################
+
+# buildifier is written in Go and hence needs rules_go to be built.
+# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-master",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,20 +9,6 @@ http_archive(
     urls = ["https://github.com/tweag/rules_haskell/archive/6604b8c19701a64986e98d475959ff2a2e8a1379.tar.gz"],
 )
 
-http_archive(
-    name = "org_nixos_patchelf",
-    build_file_content = """
-cc_binary(
-    name = "patchelf",
-    srcs = ["src/patchelf.cc", "src/elf.h"],
-    copts = ["-DPAGESIZE=4096", '-DPACKAGE_STRING=\\\\"patchelf\\\\"'],
-    visibility = [ "//visibility:public" ],
-)
-""",
-    strip_prefix = "patchelf-1fa4d36fead44333528cbee4b5c04c207ce77ca4",
-    urls = ["https://github.com/NixOS/patchelf/archive/1fa4d36fead44333528cbee4b5c04c207ce77ca4.tar.gz"],
-)
-
 load("@rules_haskell//haskell:repositories.bzl", "haskell_repositories")
 haskell_repositories()
 

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -1,6 +1,5 @@
 """Library and binary closures"""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
@@ -46,9 +45,7 @@ def _library_closure_impl(ctx):
     output_file = ctx.actions.declare_file(ctx.label.name + ".zip")
     cc_tools = ctx.attr._cc_toolchain.files
     files = depset(ctx.files.srcs)
-    runfiles = depset()
-    for src in ctx.attr.srcs:
-        runfiles = depset(transitive = [src.default_runfiles.files, runfiles])
+    runfiles = depset(transitive = [src.default_runfiles.files for src in ctx.attr.srcs])
 
     # find tools
     bash = ctx.actions.declare_file("bash")

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 def remove_library_flags(flags):
-  return [f for f in flags if not f.startswith("-l")]
+    return [f for f in flags if not f.startswith("-l")]
 
 def quote_list(xs):
     if [] == xs:
@@ -14,7 +14,6 @@ def quote_list(xs):
         return "'" + "' '".join(xs) + "'"
 
 def _library_closure_impl(ctx):
-
     if ctx.attr.executable:
         action_name = ACTION_NAMES.cpp_link_executable
     else:
@@ -26,8 +25,8 @@ def _library_closure_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     compiler = cc_common.get_tool_for_action(
-        feature_configuration=feature_configuration,
-        action_name=action_name
+        feature_configuration = feature_configuration,
+        action_name = action_name,
     )
     compiler_variables = cc_common.create_compile_variables(
         feature_configuration = feature_configuration,
@@ -39,9 +38,9 @@ def _library_closure_impl(ctx):
         variables = compiler_variables,
     ))
     compiler_env = cc_common.get_environment_variables(
-       feature_configuration = feature_configuration,
-       action_name = action_name,
-       variables = compiler_variables,
+        feature_configuration = feature_configuration,
+        action_name = action_name,
+        variables = compiler_variables,
     )
 
     output_file = ctx.actions.declare_file(ctx.label.name + ".zip")
@@ -65,7 +64,7 @@ def _library_closure_impl(ctx):
         ln -s $(command -v ldd) {ldd}
         ln -s $(command -v grep) {grep}
         ln -s $(command -v scanelf) {scanelf}
-        """.format(ldd = ldd.path, bash=bash.path, grep = grep.path, scanelf = scanelf.path),
+        """.format(ldd = ldd.path, bash = bash.path, grep = grep.path, scanelf = scanelf.path),
     )
 
     excludes = quote_list(ctx.attr.excludes)
@@ -153,7 +152,6 @@ def _library_closure_impl(ctx):
 
     return DefaultInfo(files = depset([output_file]))
 
-
 library_closure = rule(
     _library_closure_impl,
     attrs = {
@@ -180,7 +178,7 @@ library_closure = rule(
       library_closure(
           name = "closure"
           srcs = [":lib1", ":lib2"]
-          excludes = ["libexclude_this\.so", "libthis_too\.so"]
+          excludes = ["libexclude_this\\.so", "libthis_too\\.so"]
           ...
       )
       ```
@@ -203,7 +201,7 @@ library_closure = rule(
                   is just a shared library `libclodl-top.so` that depends on
                   all the other libraries in the closure.
 
-    """
+    """,
 )
 
 def binary_closure(name, src, excludes = [], **kwargs):
@@ -227,7 +225,7 @@ def binary_closure(name, src, excludes = [], **kwargs):
       binary_closure(
           name = "closure"
           src = "hello-cc"
-          excludes = ["libexclude_this\.so", "libthis_too\.so"]
+          excludes = ["libexclude_this\\.so", "libthis_too\\.so"]
           ...
       )
       ```
@@ -260,10 +258,10 @@ def binary_closure(name, src, excludes = [], **kwargs):
     cat - "$$zip_file_path" > $@ <<END
     #!/usr/bin/env bash
     set -eu
-    tmpdir=\$$(mktemp -d)
-    trap "rm -rf '\$$tmpdir'" EXIT
-    unzip -q "\$$0" -d "\$$tmpdir" 2> /dev/null || true
-    "\$$tmpdir/clodl-exe-top"
+    tmpdir=\\$$(mktemp -d)
+    trap "rm -rf '\\$$tmpdir'" EXIT
+    unzip -q "\\$$0" -d "\\$$tmpdir" 2> /dev/null || true
+    "\\$$tmpdir/clodl-exe-top"
     exit 0
 END
     chmod +x $@

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -76,7 +76,7 @@ def _library_closure_impl(ctx):
         srclibs="$1"
         output_file="$2"
         executable={executable}
-        tmpdir=$(mktemp -d)
+        tmpdir=$(mktemp -d -p $PWD)
 
         PATH={tools}:$PATH {deps} $srclibs -- {excludes} > libs.txt
         for lib in $srclibs
@@ -121,7 +121,7 @@ def _library_closure_impl(ctx):
         [ '{excludes}' ] || exit 0
 
         # Produce a file with regexes to exclude libs from the zip.
-        tmpx_file=$(mktemp tmpexcludes_file.XXXXXX)
+        tmpx_file=$(mktemp tmpexcludes_file.XXXXXX -p $PWD)
         # Note: quotes are important in shell expansion to preserve newlines.
         echo '{n_excludes}' > $tmpx_file
 

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -109,7 +109,6 @@ def _library_closure_impl(ctx):
         else
           echo -o $tmpdir/clodl-exe-top >> params
         fi
-        echo compiler: {compiler}
         {compiler} @params
 
         # zip all the libraries

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,8 +1,17 @@
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 stardoc(
     name = "docs",
     input = "//clodl:clodl.bzl",
     out = "doc.md",
-    deps = ["@bazel_skylib//lib:paths"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        ":refs",
+    ],
+)
+
+bzl_library(
+    name = "refs",
+    srcs = ["@bazel_tools//tools:bzl_srcs"],
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -3,11 +3,11 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 stardoc(
     name = "docs",
-    input = "//clodl:clodl.bzl",
     out = "doc.md",
+    input = "//clodl:clodl.bzl",
     deps = [
-        "@bazel_skylib//lib:paths",
         ":refs",
+        "@bazel_skylib//lib:paths",
     ],
 )
 

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,6 @@ mkShell {
     binutils
     cacert
     git
-    less
     nix
     openjdk11
     python3
@@ -16,5 +15,7 @@ mkShell {
     unzip
     which
     zip
+    # convenience dependencies
+    less
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ mkShell {
     binutils
     cacert
     git
+    less
     nix
     openjdk11
     python3

--- a/src/main/bash/deps.sh
+++ b/src/main/bash/deps.sh
@@ -106,7 +106,7 @@ traverse_deps() {
     do
         if [ ! ${dont_print["$lib"]+defined} ]
         then
-           echo -en "$lib\t"; realpath ${paths["$lib"]}
+           echo ${paths["$lib"]}
            dont_print["$lib"]=1
            traverse_deps "${paths["$lib"]}"
         fi


### PR DESCRIPTION
So far, `library_closure` was implemented with a bunch of rules each trying to do a small piece of work. It turns out, however,  that the composition of these rules introduced more issues than it solved.

1. There was a rule to rename inputs so they looked like libraries to the cc_binary rule that we had.
1. There was a rule to collect the paths of dependencies of a set of source libraries.
1. There was a rule to transform the collected paths into a couple of files with arguments for the linker.
1. There was a rule to output the runfiles of the source libraries.
1. There was a cc_binary rule to link all the runfiles and the source libraries.
1. There was a final rule to put all the libraries in a zip file.

Each step had its own set of quirks.
* cc_binary wouldn't accept files to link that didn't end in .o or .so. It rejects binaries in particular, which motivated rule (1).
* The paths that rule (2) collected pointed sometimes to the nix store, sometimes to the bazel cache, and sometimes to local sandboxes which would become invalid in subsequent rules.
* Rule (4) would fail if the source libraries had no runfiles, because then bazel would complain that the rule produced no outputs.
* Rule (5) cc_binary, required the libraries to link as inputs, but since they were discovered at execution time, it was impossible to plug the inputs to it. We therefore gave the paths to the libraries in files produced by rule (3), and hoped that the paths would still be valid when the linker reached for them. 

All these quirks together made challenging to fix an issue without introducing new ones. Therefore this PR, which implements `library_closure` on a single rule.

Firstly, there is some setup to collect the paths to required tools like the C compiler, scanelf and ldd. Then we collect the dependencies, link them together, and build the zip file in a single run_shell action. Thus, no bazel constraint crops up between these tasks. There is no longer a composition problem.

Additionally, I dropped support for the `outzip` attribute of `library_closure` that would allow the caller to choose the name of the output zip file. This was a feature supporting sparkle that isn't hard to address in sparkle itself.