### PR TITLE
Set host platform in bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-common --host_javabase=@local_jdk//:jdk
+build --host_javabase=@local_jdk//:jdk
 try-import .bazelrc.local

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
 build --host_javabase=@local_jdk//:jdk
+build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 try-import .bazelrc.local

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install NixOS
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=./nixpkgs.nix
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Install NixOS
         uses: cachix/install-nix-action@v18
         with:
@@ -29,7 +29,6 @@ jobs:
       - name: Configure
         run: |
           mkdir -p ~/repo-cache ~/disk-cache
-          echo build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host > .bazelrc.local
 
       - name: Mount Bazel cache
         uses: actions/cache/restore@v3


### PR DESCRIPTION
- Move `--host_javabase` option to `build`
- Set up host platform to support nix

Note: I also had to upgrade the install-nix-action as the old version was failing to install nix on macos: https://github.com/tweag/clodl/actions/runs/7420022603/job/20190711609
