### PR TITLE
Call clodl-top0 with an interpreter if one was packed

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -66,7 +66,6 @@ binary_closure(
     excludes = [
         "^/System/",
         "^/usr/lib/",
-        "ld-linux-x86-64\\.so.*",
         "libgcc_s\\.so.*",
         "libc\\.so.*",
         "libdl\\.so.*",
@@ -85,7 +84,6 @@ library_closure(
     excludes = [
         "^/System/",
         "^/usr/lib/",
-        "ld-linux-x86-64\\.so.*",
         "libgcc_s\\.so.*",
         "libc\\.so.*",
         "libdl\\.so.*",

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -290,6 +290,10 @@ def binary_closure(name, src, excludes = [], **kwargs):
     )
 
     # Prepend a script to execute the closure
+    #
+    # The closure will include the ELF interpreter in linux since this
+    # is considered a dependency by the copy-closure script, unless the
+    # user excludes it with a regex.
     native.genrule(
         name = name,
         srcs = [zip_name],

--- a/clodl/clodl.bzl
+++ b/clodl/clodl.bzl
@@ -303,7 +303,8 @@ def binary_closure(name, src, excludes = [], **kwargs):
     tmpdir=\\$$(mktemp -d)
     trap "rm -rf '\\$$tmpdir'" EXIT
     unzip -q "\\$$0" -d "\\$$tmpdir" 2> /dev/null || true
-    "\\$$tmpdir/clodl-top0"
+    INTERP=\\$$(ls -1 \\$$tmpdir/ld-linux-* | head -1)
+    \\$$INTERP "\\$$tmpdir/clodl-top0"
     exit 0
 END
     chmod +x $@


### PR DESCRIPTION
All of this time, clodl has been requiring machines to put the ELF interpreter at the same path.

In this patch, the interpreter is looked up among the unpacked libraries, and it is called explicitly. This should make possible for the closures to run independently of where the running machines have their interpreters.

Fixes #32